### PR TITLE
Update pom.xml

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -75,7 +75,7 @@
 			<plugin>
 				<groupId>com.akathist.maven.plugins.launch4j</groupId>
 				<artifactId>launch4j-maven-plugin</artifactId>
-				<version>1.7.15</version>
+				<version>2.1.0</version>
 				<executions>
 					<execution>
 						<id>l4j-clui</id>


### PR DESCRIPTION
bumped launch4j version to 2.1.0 to fix failing maven build:

`[ERROR] Failed to execute goal com.akathist.maven.plugins.launch4j:launch4j-maven-plugin:1.7.15:launch4j (l4j-clui) on project jds: Execution l4j-clui of goal com.akathist.maven.plugins.launch4j:launch4j-maven-plugin:1.7.15:launch4j failed: An API incompatibility was encountered while executing com.akathist.maven.plugins.launch4j:launch4j-maven-plugin:1.7.15:launch4j: java.lang.ExceptionInInitializerError: null`

2.1.0 was the smallest version number possible.